### PR TITLE
Add whitepaper subdomain redirect for /developer/develop-on-core/quick-links

### DIFF
--- a/src/pages/developer/develop-on-core/quick-links.js
+++ b/src/pages/developer/develop-on-core/quick-links.js
@@ -1,0 +1,21 @@
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Layout from '@theme/Layout';
+
+export default function Whitepaper() {
+  const { siteConfig } = useDocusaurusContext();
+
+  return (
+    <Layout
+      title={`Hello from ${siteConfig.title}`}
+      description="Official Documentation for Core DAO">
+      <head>
+        <link rel="canonical" href="https://whitepaper.coredao.org/developer/develop-on-core/quick-links" />
+        <meta httpEquiv="refresh" content="0; url=https://whitepaper.coredao.org/developer/develop-on-core/quick-links" />
+        <meta charSet="utf-8" />
+      </head>
+      <main>
+        <p>Redirecting to <a href="https://whitepaper.coredao.org/developer/develop-on-core/quick-links">https://whitepaper.coredao.org/developer/develop-on-core/quick-links</a></p>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
The "Build on Core" link is broken here https://coredaofoundation.org/

Redirect works locally