### PR TITLE
dRPC added to the 3rd party provider list

### DIFF
--- a/docs/Dev-Guide/rpc-list.md
+++ b/docs/Dev-Guide/rpc-list.md
@@ -26,3 +26,4 @@ Remote Procedure Call (RPC) endpoints are crucial for developers and application
 * **1RPC:** https://1rpc.io/core 
 * **INFSTONES:** https://core.public.infstones.com 
 * **IceCreamSwap:** https://rpc-core.icecreamswap.com
+* **dRPC** https://core.drpc.org


### PR DESCRIPTION
Public endpoint page for Core from dRPC: https://drpc.org/chainlist/core